### PR TITLE
Fix return value of Matter.Vertices.create()

### DIFF
--- a/types/matter-js/index.d.ts
+++ b/types/matter-js/index.d.ts
@@ -2963,8 +2963,9 @@ declare namespace Matter {
         * @method create
         * @param {vector[]} points
         * @param {body} body
+        * @return {vertices} vertices
         */
-        static create(points: Array<Vector>, body: Body): void;
+        static create(points: Array<Vector>, body: Body): Array<Vector>;
 
         /**
          * Parses a string containing ordered x y pairs separated by spaces (and optionally commas),


### PR DESCRIPTION
Matter.Vertices.create returns an array of vectors:
```
EG: body.vertices = Vertices.create(vertices, this.body);
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://brm.io/matter-js/docs/classes/Vertices.html>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. If for reason the any rule need to be disabled, disable it for that line using `// tslint:disable-next-line [ruleName]` and not for whole package so that the need for disabling can be reviewed.
